### PR TITLE
add default values and fix long linkage for pose_graph_tools_ros

### DIFF
--- a/pose_graph_tools/include/pose_graph_tools/pose_graph.h
+++ b/pose_graph_tools/include/pose_graph_tools/pose_graph.h
@@ -12,7 +12,8 @@ struct PoseGraph {
   using Ptr = std::shared_ptr<PoseGraph>;
   using ConstPtr = std::shared_ptr<const PoseGraph>;
 
-  uint64_t stamp_ns;
+  std::string frame_id;
+  uint64_t stamp_ns = 0;
   std::vector<PoseGraphNode> nodes;
   std::vector<PoseGraphEdge> edges;
 

--- a/pose_graph_tools/include/pose_graph_tools/pose_graph_edge.h
+++ b/pose_graph_tools/include/pose_graph_tools/pose_graph_edge.h
@@ -10,8 +10,10 @@ namespace pose_graph_tools {
 struct PoseGraphEdge {
   using Ptr = std::shared_ptr<PoseGraphEdge>;
   using ConstPtr = std::shared_ptr<const PoseGraphEdge>;
+  using Covariance = Eigen::Matrix<double, 6, 6>;
 
   enum Type : int {
+    UNKNOWN = -1,
     ODOM = 0,
     LOOPCLOSE = 1,
     LANDMARK = 2,
@@ -21,19 +23,20 @@ struct PoseGraphEdge {
     MESH_POSE = 6,
     PRIOR = 7,
     REJECTED_PRIOR = 8,
-  };
+  } type = Type::UNKNOWN;
 
-  uint64_t key_from;
-  uint64_t key_to;
+  uint64_t key_from = 0;
+  uint64_t key_to = 0;
 
-  int32_t robot_from;
-  int32_t robot_to;
+  int32_t robot_from = 0;
+  int32_t robot_to = 0;
 
-  Type type;
-  uint64_t stamp_ns;
+  // Optional timestamp the edge was computed at
+  uint64_t stamp_ns = 0;
 
-  Eigen::Affine3d pose;
-  Eigen::Matrix<double, 6, 6> covariance;
+  Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  // Use ROS convention of negative covariance to indicate unset
+  Covariance covariance = Covariance::Constant(-1.0);
 
   friend std::ostream& operator<<(std::ostream& os, const PoseGraphEdge& edge);
 };

--- a/pose_graph_tools/include/pose_graph_tools/pose_graph_node.h
+++ b/pose_graph_tools/include/pose_graph_tools/pose_graph_node.h
@@ -11,10 +11,11 @@ struct PoseGraphNode {
   using Ptr = std::shared_ptr<PoseGraphNode>;
   using ConstPtr = std::shared_ptr<const PoseGraphNode>;
 
-  uint64_t stamp_ns;
-  int32_t robot_id;
-  uint64_t key;
-  Eigen::Affine3d pose;
+  std::string frame_id;
+  uint64_t stamp_ns = 0;
+  int32_t robot_id = 0;
+  uint64_t key = 0;
+  Eigen::Affine3d pose = Eigen::Affine3d::Identity();
 
   friend std::ostream& operator<<(std::ostream& os, const PoseGraphNode& node);
 };

--- a/pose_graph_tools_msgs/msg/PoseGraph.msg
+++ b/pose_graph_tools_msgs/msg/PoseGraph.msg
@@ -1,3 +1,4 @@
+# Timestamp of last update and map frame ID
 std_msgs/Header header
 
 # Nodes and edges

--- a/pose_graph_tools_msgs/msg/PoseGraphEdge.msg
+++ b/pose_graph_tools_msgs/msg/PoseGraphEdge.msg
@@ -9,13 +9,16 @@ int32 robot_to
 int32 type
 
 # Type enums
-int32 ODOM      = 0
+int32 UNKNOWN = -1
+int32 ODOM = 0
 int32 LOOPCLOSE = 1
-int32 LANDMARK  = 2
+int32 LANDMARK = 2
 int32 REJECTED_LOOPCLOSE = 3
 int32 MESH = 4
 int32 POSE_MESH = 5
 int32 MESH_POSE = 6
+int32 PRIOR = 7
+int32 REJECTED_PRIOR = 8
 
 # Transforms in ede
 geometry_msgs/Pose pose

--- a/pose_graph_tools_msgs/msg/PoseGraphNode.msg
+++ b/pose_graph_tools_msgs/msg/PoseGraphNode.msg
@@ -1,7 +1,8 @@
+# Timestamp and frame ID of the pose
 std_msgs/Header header
-
+# Robot ID of the pose
 int32 robot_id
-
+# Key of the pose
 uint64 key
-
+# Pose of the robot body
 geometry_msgs/Pose pose

--- a/pose_graph_tools_ros/CMakeLists.txt
+++ b/pose_graph_tools_ros/CMakeLists.txt
@@ -19,18 +19,24 @@ find_package(rclcpp_components REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
+# Fake target that collects ament dependencies to allow for private linakge to
+# the main target
+add_library(private_deps INTERFACE)
+ament_target_dependencies(private_deps INTERFACE visualization_msgs
+                          interactive_markers tf2_eigen)
+
 add_library(${PROJECT_NAME} SHARED src/conversions.cpp src/visualizer.cpp
                                    src/utils.cpp)
 target_include_directories(
   ${PROJECT_NAME}
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-         "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
-  PRIVATE ${visualization_msgs_INCLUDE_DIRS})
+         "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(
-  ${PROJECT_NAME} PRIVATE interactive_markers::interactive_markers
-                          tf2_eigen::tf2_eigen ${visualization_msgs_LIBRARIES})
-ament_target_dependencies(${PROJECT_NAME} PUBLIC pose_graph_tools
-                          pose_graph_tools_msgs rclcpp rclcpp_components)
+  ${PROJECT_NAME}
+  PUBLIC pose_graph_tools::pose_graph_tools
+  PRIVATE private_deps)
+ament_target_dependencies(${PROJECT_NAME} PUBLIC pose_graph_tools_msgs rclcpp
+                          rclcpp_components)
 
 rclcpp_components_register_node(
   ${PROJECT_NAME} PLUGIN pose_graph_tools_ros::Visualizer EXECUTABLE

--- a/pose_graph_tools_ros/src/conversions.cpp
+++ b/pose_graph_tools_ros/src/conversions.cpp
@@ -46,11 +46,11 @@ void fromMsg(const pose_graph_msgs::BowQueries& src, BowQueries& dest) {
 }
 
 void toMsg(const PoseGraphEdge& src, pose_graph_msgs::PoseGraphEdge& dest) {
+  dest.type = static_cast<int>(src.type);
   dest.key_from = src.key_from;
   dest.key_to = src.key_to;
   dest.robot_from = src.robot_from;
   dest.robot_to = src.robot_to;
-  dest.type = static_cast<int>(src.type);
   dest.header.stamp = rclcpp::Time(src.stamp_ns);
   tf2::convert(src.pose, dest.pose);
 
@@ -63,12 +63,12 @@ void toMsg(const PoseGraphEdge& src, pose_graph_msgs::PoseGraphEdge& dest) {
 }
 
 void fromMsg(const pose_graph_msgs::PoseGraphEdge& src, PoseGraphEdge& dest) {
+  dest.type = static_cast<PoseGraphEdge::Type>(src.type);
   dest.key_from = src.key_from;
   dest.key_to = src.key_to;
   dest.robot_from = src.robot_from;
   dest.robot_to = src.robot_to;
   dest.stamp_ns = rclcpp::Time(src.header.stamp).nanoseconds();
-  dest.type = static_cast<PoseGraphEdge::Type>(src.type);
   tf2::convert(src.pose, dest.pose);
 
   // Store covariance in row-major order.
@@ -81,6 +81,7 @@ void fromMsg(const pose_graph_msgs::PoseGraphEdge& src, PoseGraphEdge& dest) {
 
 void toMsg(const PoseGraphNode& src, pose_graph_msgs::PoseGraphNode& dest) {
   dest.header.stamp = rclcpp::Time(src.stamp_ns);
+  dest.header.frame_id = src.frame_id;
   dest.key = src.key;
   dest.robot_id = src.robot_id;
   tf2::convert(src.pose, dest.pose);
@@ -88,6 +89,7 @@ void toMsg(const PoseGraphNode& src, pose_graph_msgs::PoseGraphNode& dest) {
 
 void fromMsg(const pose_graph_msgs::PoseGraphNode& src, PoseGraphNode& dest) {
   dest.stamp_ns = rclcpp::Time(src.header.stamp).nanoseconds();
+  dest.frame_id = src.header.frame_id;
   dest.key = src.key;
   dest.robot_id = src.robot_id;
   tf2::convert(src.pose, dest.pose);
@@ -95,11 +97,14 @@ void fromMsg(const pose_graph_msgs::PoseGraphNode& src, PoseGraphNode& dest) {
 
 void toMsg(const PoseGraph& src, pose_graph_msgs::PoseGraph& dest) {
   dest.header.stamp = rclcpp::Time(src.stamp_ns);
+  dest.header.frame_id = src.frame_id;
+
   dest.nodes.reserve(src.nodes.size());
   for (const auto& node : src.nodes) {
     auto& dest_node = dest.nodes.emplace_back();
     toMsg(node, dest_node);
   }
+
   dest.edges.reserve(src.edges.size());
   for (const auto& edge : src.edges) {
     auto& dest_edge = dest.edges.emplace_back();
@@ -109,11 +114,14 @@ void toMsg(const PoseGraph& src, pose_graph_msgs::PoseGraph& dest) {
 
 void fromMsg(const pose_graph_msgs::PoseGraph& src, PoseGraph& dest) {
   dest.stamp_ns = rclcpp::Time(src.header.stamp).nanoseconds();
+  dest.frame_id = src.header.frame_id;
+
   dest.nodes.reserve(src.nodes.size());
   for (const auto& node : src.nodes) {
     auto& dest_node = dest.nodes.emplace_back();
     fromMsg(node, dest_node);
   }
+
   dest.edges.reserve(src.edges.size());
   for (const auto& edge : src.edges) {
     auto& dest_edge = dest.edges.emplace_back();


### PR DESCRIPTION
@yunzc Fixing some warnings that I get for all of the uninitialized fields in the edge struct (and fixes the ~2 minute build time for `pose_graph_tools`). Also adds missing frame IDs on the c++ side that are required for the pose graph message translation to work round trip (i.e., `ros -> non-ros -> ros` should get the same message). Aaron and I were talking about also adding timestamps and other information to `PoseGraphEdge` to handle the external loop closure case better, but I decided that would be better as a separate message